### PR TITLE
Remove hostname from app.listen

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -31,6 +31,6 @@ app.get("/", async (req, res) => {
 });
 
 // start the Express server
-app.listen(port, '0.0.0.0', () => {
+app.listen(port, hostname, () => {
   console.log(`server started at http://${hostname}:${port}`);
 });

--- a/server.ts
+++ b/server.ts
@@ -31,6 +31,6 @@ app.get("/", async (req, res) => {
 });
 
 // start the Express server
-app.listen(port, hostname, () => {
+app.listen(port, () => {
   console.log(`server started at http://${hostname}:${port}`);
 });

--- a/server.ts
+++ b/server.ts
@@ -8,7 +8,7 @@ app.use(cors());
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 
-const hostname = process.env.HOST || "localhost";
+const hostname = process.env.HOST || "0.0.0.0";
 const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 8082;
 
 app.post("/move", async (req: Request, res: Response) => {
@@ -31,6 +31,6 @@ app.get("/", async (req, res) => {
 });
 
 // start the Express server
-app.listen(port, () => {
+app.listen(port, '0.0.0.0', () => {
   console.log(`server started at http://${hostname}:${port}`);
 });


### PR DESCRIPTION
Running into issues with port binding if we specify the hostname for an express server 

https://stackoverflow.com/questions/48349056/cant-connect-to-node-server-on-amazon-ec2/48349104